### PR TITLE
(3) refactored autocomplete

### DIFF
--- a/examples/calculator/calculator.js
+++ b/examples/calculator/calculator.js
@@ -18,18 +18,16 @@ vorpal.command('add [numbers...]', 'Adds numbers together')
   });
 
 vorpal.command('double [values...]', 'Doubles a value on each tab press')
-  .autocompletion(function (text, iteration, cb) {
-    if (iteration > 1000000) {
-      cb(undefined, ['cows', 'hogs', 'horses']);
-    } else {
-      var number = String(text).trim();
-      if (!isNaN(number)) {
-        number = (number < 1) ? 1 : number;
-        cb(undefined, 'double ' + number * 2);
-      } else {
-        cb(undefined, 'double 2');
+  .autocomplete({
+      data: function (text, cb) {
+          var number = String(text).trim();
+          if (!isNaN(number)) {
+              number = (number < 1) ? 1 : number;
+              cb(undefined, 'double ' + number * 2);
+          } else {
+              cb(undefined, 'double 2');
+          }
       }
-    }
   })
   .action(function (args, cb) {
       cb();

--- a/src/autocomplete-utils.ts
+++ b/src/autocomplete-utils.ts
@@ -1,0 +1,326 @@
+import _                   from 'lodash'
+import strip               from 'strip-ansi'
+import autocomplete from './autocomplete'
+import {
+    AutocompleteCallback,
+    AutocompleteConfigFn,
+    AutocompleteMatch,
+    AutocompleteOptions,
+    IAutocompleteConfig,
+    Input,
+} from './types/autocomplete'
+import {ICommand, IVorpal} from './types/types'
+
+/**
+ * Tracks how many times tab was pressed
+ * based on whether the UI changed.
+ *
+ * @param {AutocompleteMatch} match
+ * @param {Boolean} freezeTabs
+ * @return {String} result
+ * @api private
+ */
+export function handleTabCounts(match: AutocompleteMatch, freezeTabs: boolean): AutocompleteMatch {
+    let result;
+    if (_.isArray(match)) {
+        this._tabCount += 1;
+        if (this._tabCount > 1) {
+            result = match.length === 0 ? undefined : match;
+        }
+    } else {
+        this._tabCount = freezeTabs === true ? this._tabCount + 1 : 0;
+        result = match;
+    }
+    return result;
+}
+
+/**
+ * Looks for a potential exact match
+ * based on given data.
+ *
+ * @param {String} ctx
+ * @param {Array} data
+ * @param {Object} options
+ * @return {String}
+ * @api private
+ */
+export function getMatch(ctx: string, data: string[], options?: AutocompleteOptions): AutocompleteMatch {
+    // Look for a command match, eliminating and then
+    // re-introducing leading spaces.
+    const len = ctx.length;
+    const trimmed = ctx.trimLeft();
+    const match = autocomplete.match(trimmed, data.slice(), options);
+    if (_.isArray(match)) {
+        return match;
+    }
+    const prefix = new Array(len - trimmed.length + 1).join(' ');
+
+    // If we get an autocomplete match on a command, put the leading spaces back in and finish it.
+    return match ? prefix + match : undefined
+}
+
+/**
+ * Takes the input object and assembles
+ * the final result to display on the screen.
+ *
+ * @param {Object} input
+ * @return {AutocompleteMatch}
+ * @api private
+ */
+export function assembleInput(input: Input): AutocompleteMatch {
+    if (_.isArray(input.context)) {
+        return input.context;
+    }
+    const result = (input.prefix || '') + (input.context || '') + (input.suffix || '');
+    return strip(result);
+}
+
+/**
+ * Reduces an array of possible
+ * matches to list based on a given
+ * string.
+ *
+ * @param {String} str
+ * @param {Array} data
+ * @return {Array}
+ * @api private
+ */
+export function filterData(str: string = '', data: string[]) {
+    data = data || [];
+    let ctx = String(str).trim();
+    const slashParts = ctx.split('/');
+    ctx = slashParts.pop();
+    const wordParts = String(ctx)
+        .trim()
+        .split(' ');
+
+    return data.filter(function(item) {
+        return strip(item).slice(0, ctx.length) === ctx;
+    }).map(function(item) {
+        let parts = String(item)
+            .trim()
+            .split(' ');
+        if (parts.length > 1) {
+            parts = parts.slice(wordParts.length);
+            return parts.join(' ');
+        }
+        return item;
+    });
+}
+
+/**
+ * Takes the user's current prompt
+ * string and breaks it into its
+ * integral parts for analysis and
+ * modification.
+ *
+ * @param {String} str
+ * @param {Number} idx
+ * @return {Object}
+ * @api private
+ */
+export function parseInput(str: string = '', idx: number): Input {
+    const raw = String(str);
+    const sliced = raw.slice(0, idx);
+    const sections = sliced.split('|');
+    const prefixParts = sections.slice(0, sections.length - 1) || [];
+    prefixParts.push('');
+    const prefix = prefixParts.join('|');
+    const suffix = getSuffix(raw.slice(idx));
+    const context = sections[sections.length - 1];
+    return {
+        raw,
+        prefix,
+        suffix,
+        context,
+    };
+}
+
+/**
+ * Takes the context after a
+ * matched command and figures
+ * out the applicable context,
+ * including assigning its role
+ * such as being an option
+ * parameter, etc.
+ *
+ * @param {Object} input
+ * @return {Object}
+ * @api private
+ */
+export function parseMatchSection(input: Input<string>) {
+    const parts = (input.context || '').split(' ');
+    const last = parts.pop();
+    const beforeLast = strip(parts[parts.length - 1] || '').trim();
+    if (beforeLast.slice(0, 1) === '-') {
+        input.option = beforeLast;
+    }
+    input.context = last;
+    input.prefix = (input.prefix || '') + parts.join(' ') + ' ';
+    return input;
+}
+
+/**
+ * Returns a cleaned up version of the
+ * remaining text to the right of the cursor.
+ *
+ * @param {String} suffix
+ * @return {String}
+ * @api private
+ */
+export function getSuffix(suffix: string) {
+    suffix = suffix.slice(0, 1) === ' ' ? suffix : suffix.replace(/.+?(?=\s)/, '');
+    suffix = suffix.slice(1, suffix.length);
+    return suffix;
+}
+
+/**
+ * Compile all available commands and aliases
+ * in alphabetical order.
+ *
+ * @param {Array} cmds
+ * @return {Array}
+ * @api private
+ */
+export function getCommandNames(cmds: ICommand[]): string[] {
+    let commands = _.map(cmds, '_name');
+    commands = commands.concat.apply(commands, _.map(cmds, '_aliases'));
+    commands.sort();
+    return commands;
+}
+
+/**
+ * When we know that we've
+ * exceeded a known command, grab
+ * on to that command and return it,
+ * fixing the overall input context
+ * at the same time.
+ *
+ * @param {Object} input
+ * @param {Array} commandNames
+ * @return {Object}
+ * @api private
+ */
+export function getMatchObject(this: IVorpal, input: Input<string>, commandNames: string[]) {
+    const len = input.context.length;
+    const trimmed = String(input.context).trimLeft();
+    let prefix = new Array(len - trimmed.length + 1).join(' ');
+    let match: string;
+    let suffix;
+
+    commandNames.forEach(function(cmd) {
+        const nextChar = trimmed.substr(cmd.length, 1);
+        if (trimmed.substr(0, cmd.length) === cmd && String(cmd).trim() !== '' && nextChar === ' ') {
+            match = cmd;
+            suffix = trimmed.substr(cmd.length);
+            prefix += trimmed.substr(0, cmd.length);
+        }
+    });
+
+    let matchObject: ICommand = match
+        ? _.find(this.parent.commands, { _name: String(match).trim() })
+        : undefined;
+
+    if (!matchObject) {
+        this.parent.commands.forEach(function(cmd) {
+            if ((cmd._aliases || []).indexOf(String(match).trim()) > -1) {
+                matchObject = cmd;
+            }
+            return;
+        });
+    }
+
+    if (!matchObject) {
+        matchObject = this.parent.commands.find(cmd => !_.isNil(cmd._catch));
+        if (matchObject) {
+            suffix = input.context;
+        }
+    }
+
+    if (!matchObject) {
+        prefix = input.context;
+        suffix = '';
+    }
+
+    if (matchObject) {
+        input.match = matchObject;
+        input.prefix += prefix;
+        input.context = suffix;
+    }
+
+    return input;
+}
+
+/**
+ * Takes a known matched command, and reads
+ * the applicable data by calling its autocompletion
+ * instructions, whether it is the command's
+ * autocompletion or one of its options.
+ *
+ * @param {Object} input
+ * @param {Function} cb
+ * @return {Array}
+ * @api private
+ */
+export function getMatchData(input: Input<string>, cb: AutocompleteCallback) {
+    const string = input.context;
+    const cmd = input.match;
+    const midOption = String(string).trim().slice(0, 1) === '-';
+    const afterOption = input.option !== undefined;
+
+    if (midOption === true && !cmd._allowUnknownOptions) {
+        const results = [];
+        for (let i = 0; i < cmd.options.length; ++i) {
+            const long = cmd.options[i].long;
+            const short = cmd.options[i].short;
+            if (!long && short) {
+                results.push(short);
+            } else if (long) {
+                results.push(long);
+            }
+        }
+        cb(results);
+        return;
+    }
+
+    if (afterOption === true) {
+        const opt = strip(input.option).trim();
+        const match = cmd.options.find(o => o.short === opt || o.long === opt);
+        if (match) {
+            const config = match.autocomplete;
+            handleDataFormat(string, config, cb);
+            return;
+        }
+    }
+
+    const conf = cmd._autocomplete;
+    const confFn = conf && !_.isArray(conf) && conf.data ? conf.data : conf;
+    handleDataFormat(string, confFn, cb);
+}
+
+function handleDataFormat(str: AutocompleteMatch, config: IAutocompleteConfig | AutocompleteConfigFn, cb: AutocompleteCallback) {
+    let data: string[] = [];
+    if (_.isArray(config)) {
+        data = config;
+    } else if (_.isFunction(config)) {
+        const cbk = config.length < 2
+            ? function() {}
+            : function(err, resp: string[]) {
+                cb(resp || []);
+            };
+        const res = config(str, cbk);
+
+        if (res instanceof Promise) {
+            res.then(function(resp) {
+                    cb(resp);
+                })
+                .catch(function(err) {
+                    cb(err);
+                });
+        } else if (config.length < 2) {
+            cb(res);
+        }
+    } else {
+        cb(data);
+    }
+}

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -1,18 +1,22 @@
-import _ from 'lodash';
+import {clone} from 'lodash';
 import strip from 'strip-ansi';
-import Command from './command';
-import { IVorpal } from './types';
+import {
+  assembleInput, filterData,
+  getCommandNames,
+  getMatch, getMatchData,
+  getMatchObject,
+  handleTabCounts,
+  parseInput, parseMatchSection,
+} from './autocomplete-utils'
+import {
+  AutocompleteConfigCallback,
+  AutocompleteMatch,
+  AutocompleteOptions,
+  IAutocomplete,
+  Input,
+} from './types/autocomplete'
 
-interface Input {
-  raw;
-  prefix;
-  suffix;
-  context;
-  match?: Command;
-  option?;
-}
-
-const autocomplete = {
+const autocomplete: IAutocomplete = {
   /**
    * Handles tabbed autocompletion.
    *
@@ -24,22 +28,22 @@ const autocomplete = {
    * - Supports piping.
    *
    * @param {String} str
+   * @param {Function} cb
    * @return {String} cb
    * @api public
    */
-
-  exec(str, cb) {
+  exec(str: string, cb: AutocompleteConfigCallback): void {
     let input = parseInput(str, this.parent.ui._activePrompt.screen.rl.cursor);
     const commands = getCommandNames(this.parent.commands);
-    const vorpalMatch = getMatch(input.context, commands, { ignoreSlashes: true });
+    const vorpalMatch = getMatch(input.context as string, commands, { ignoreSlashes: true });
     let freezeTabs = false;
 
-    const end = innerStr => {
+    const end = (innerStr: AutocompleteMatch) => {
       const res = handleTabCounts.call(this, innerStr, freezeTabs);
       cb(undefined, res);
     };
 
-    const evaluateTabs = innerInput => {
+    const evaluateTabs = (innerInput: Input) => {
       if (innerInput.context && innerInput.context[innerInput.context.length - 1] === '/') {
         freezeTabs = true;
       }
@@ -53,21 +57,22 @@ const autocomplete = {
     }
 
     input = getMatchObject.call(this, input, commands);
+
     if (input.match) {
       input = parseMatchSection.call(this, input);
-      getMatchData.call(this, input, function(data) {
-        const dataMatch = getMatch(input.context, data);
+      getMatchData.call(this, input, function(data: string[]) {
+        const dataMatch = getMatch(input.context as string, data);
         if (dataMatch) {
           input.context = dataMatch;
           evaluateTabs(input);
           end(assembleInput(input));
-          return;
+        } else {
+          end(filterData(input.context as string, data));
         }
-        end(filterData(input.context, data));
       });
-      return;
+    } else {
+      end(filterData(input.context as string, commands));
     }
-    end(filterData(input.context, commands));
   },
 
   /**
@@ -76,15 +81,15 @@ const autocomplete = {
    *
    * @param {String} str
    * @param {Array} arr
+   * @param {Object} options
    * @return {String}
    * @api private
    */
-
-  match(str, arr, options) {
+  match(str: string, arr: string[], options: AutocompleteOptions): AutocompleteMatch {
     arr = arr || [];
     options = options || {};
     arr.sort();
-    const arrX = _.clone(arr);
+    const arrX = clone(arr);
     let strX = String(str);
 
     let prefix = '';
@@ -96,7 +101,7 @@ const autocomplete = {
       prefix = parts.length > 0 ? prefix + '/' : prefix;
     }
 
-    const matches = [];
+    const matches: string[] = [];
     for (let i = 0; i < arrX.length; i++) {
       if (strip(arrX[i]).slice(0, strX.length) === strX) {
         matches.push(arrX[i]);
@@ -131,335 +136,5 @@ const autocomplete = {
     return prefix + matches[0].substr(0, longestMatchLength);
   },
 };
-
-/**
- * Tracks how many times tab was pressed
- * based on whether the UI changed.
- *
- * @param {String} str
- * @return {String} result
- * @api private
- */
-
-function handleTabCounts(str, freezeTabs) {
-  let result;
-  if (_.isArray(str)) {
-    this._tabCount += 1;
-    if (this._tabCount > 1) {
-      result = str.length === 0 ? undefined : str;
-    }
-  } else {
-    this._tabCount = freezeTabs === true ? this._tabCount + 1 : 0;
-    result = str;
-  }
-  return result;
-}
-
-/**
- * Looks for a potential exact match
- * based on given data.
- *
- * @param {String} ctx
- * @param {Array} data
- * @return {String}
- * @api private
- */
-
-function getMatch(ctx, data, options?) {
-  // Look for a command match, eliminating and then
-  // re-introducing leading spaces.
-  const len = ctx.length;
-  const trimmed = ctx.replace(/^\s+/g, '');
-  let match = autocomplete.match(trimmed, data.slice(), options);
-  if (_.isArray(match)) {
-    return match;
-  }
-  const prefix = new Array(len - trimmed.length + 1).join(' ');
-  // If we get an autocomplete match on a command, finish it.
-  if (match) {
-    // Put the leading spaces back in.
-    match = prefix + match;
-    return match;
-  }
-  return undefined;
-}
-
-/**
- * Takes the input object and assembles
- * the final result to display on the screen.
- *
- * @param {Object} input
- * @return {String}
- * @api private
- */
-
-function assembleInput(input) {
-  if (_.isArray(input.context)) {
-    return input.context;
-  }
-  const result = (input.prefix || '') + (input.context || '') + (input.suffix || '');
-  return strip(result);
-}
-
-/**
- * Reduces an array of possible
- * matches to list based on a given
- * string.
- *
- * @param {String} str
- * @param {Array} data
- * @return {Array}
- * @api private
- */
-
-function filterData(str, data) {
-  data = data || [];
-  let ctx = String(str || '').trim();
-  const slashParts = ctx.split('/');
-  ctx = slashParts.pop();
-  const wordParts = String(ctx)
-    .trim()
-    .split(' ');
-  let res = data.filter(function(item) {
-    return strip(item).slice(0, ctx.length) === ctx;
-  });
-  res = res.map(function(item) {
-    let parts = String(item)
-      .trim()
-      .split(' ');
-    if (parts.length > 1) {
-      parts = parts.slice(wordParts.length);
-      return parts.join(' ');
-    }
-    return item;
-  });
-  return res;
-}
-
-/**
- * Takes the user's current prompt
- * string and breaks it into its
- * integral parts for analysis and
- * modification.
- *
- * @param {String} str
- * @param {Integer} idx
- * @return {Object}
- * @api private
- */
-
-function parseInput(str, idx): Input {
-  const raw = String(str || '');
-  const sliced = raw.slice(0, idx);
-  const sections = sliced.split('|');
-  const prefixParts = sections.slice(0, sections.length - 1) || [];
-  prefixParts.push('');
-  const prefix = prefixParts.join('|');
-  const suffix = getSuffix(raw.slice(idx));
-  const context = sections[sections.length - 1];
-  return {
-    raw,
-    prefix,
-    suffix,
-    context,
-  };
-}
-
-/**
- * Takes the context after a
- * matched command and figures
- * out the applicable context,
- * including assigning its role
- * such as being an option
- * parameter, etc.
- *
- * @param {Object} input
- * @return {Object}
- * @api private
- */
-
-function parseMatchSection(input) {
-  const parts = (input.context || '').split(' ');
-  const last = parts.pop();
-  const beforeLast = strip(parts[parts.length - 1] || '').trim();
-  if (beforeLast.slice(0, 1) === '-') {
-    input.option = beforeLast;
-  }
-  input.context = last;
-  input.prefix = (input.prefix || '') + parts.join(' ') + ' ';
-  return input;
-}
-
-/**
- * Returns a cleaned up version of the
- * remaining text to the right of the cursor.
- *
- * @param {String} suffix
- * @return {String}
- * @api private
- */
-
-function getSuffix(suffix) {
-  suffix = suffix.slice(0, 1) === ' ' ? suffix : suffix.replace(/.+?(?=\s)/, '');
-  suffix = suffix.slice(1, suffix.length);
-  return suffix;
-}
-
-/**
- * Compile all available commands and aliases
- * in alphabetical order.
- *
- * @param {Array} cmds
- * @return {Array}
- * @api private
- */
-
-function getCommandNames(cmds) {
-  let commands = _.map(cmds, '_name');
-  commands = commands.concat.apply(commands, _.map(cmds, '_aliases'));
-  commands.sort();
-  return commands;
-}
-
-/**
- * When we know that we've
- * exceeded a known command, grab
- * on to that command and return it,
- * fixing the overall input context
- * at the same time.
- *
- * @param {Object} input
- * @param {Array} commands
- * @return {Object}
- * @api private
- */
-
-function getMatchObject(this: IVorpal, input, commands) {
-  const len = input.context.length;
-  const trimmed = String(input.context).replace(/^\s+/g, '');
-  let prefix = new Array(len - trimmed.length + 1).join(' ');
-  let match;
-  let suffix;
-  commands.forEach(function(cmd) {
-    const nextChar = trimmed.substr(cmd.length, 1);
-    if (trimmed.substr(0, cmd.length) === cmd && String(cmd).trim() !== '' && nextChar === ' ') {
-      match = cmd;
-      suffix = trimmed.substr(cmd.length);
-      prefix += trimmed.substr(0, cmd.length);
-    }
-  });
-
-  let matchObject = match
-    ? _.find(this.parent.commands, { _name: String(match).trim() })
-    : undefined;
-
-  if (!matchObject) {
-    this.parent.commands.forEach(function(cmd) {
-      if ((cmd._aliases || []).indexOf(String(match).trim()) > -1) {
-        matchObject = cmd;
-      }
-      return;
-    });
-  }
-
-  if (!matchObject) {
-    matchObject = this.parent.commands.find(cmd => !_.isNil(cmd._catch));
-    if (matchObject) {
-      suffix = input.context;
-    }
-  }
-
-  if (!matchObject) {
-    prefix = input.context;
-    suffix = '';
-  }
-
-  if (matchObject) {
-    input.match = matchObject;
-    input.prefix += prefix;
-    input.context = suffix;
-  }
-  return input;
-}
-
-/**
- * Takes a known matched command, and reads
- * the applicable data by calling its autocompletion
- * instructions, whether it is the command's
- * autocompletion or one of its options.
- *
- * @param {Object} input
- * @param {Function} cb
- * @return {Array}
- * @api private
- */
-
-function getMatchData(input: Input, cb) {
-  const string = input.context;
-  const cmd = input.match;
-  const midOption =
-    String(string)
-      .trim()
-      .slice(0, 1) === '-';
-  const afterOption = input.option !== undefined;
-  if (midOption === true && !cmd._allowUnknownOptions) {
-    const results = [];
-    for (let i = 0; i < cmd.options.length; ++i) {
-      const long = cmd.options[i].long;
-      const short = cmd.options[i].short;
-      if (!long && short) {
-        results.push(short);
-      } else if (long) {
-        results.push(long);
-      }
-    }
-    cb(results);
-    return;
-  }
-
-  function handleDataFormat(str, config, callback) {
-    let data = [];
-    if (_.isArray(config)) {
-      data = config;
-    } else if (_.isFunction(config)) {
-      const cbk =
-        config.length < 2
-          ? function() {}
-          : function(resp) {
-              callback(resp || []);
-            };
-      const res = config(str, cbk);
-      if (res && _.isFunction(res.then)) {
-        res
-          .then(function(resp) {
-            callback(resp);
-          })
-          .catch(function(err) {
-            callback(err);
-          });
-      } else if (config.length < 2) {
-        callback(res);
-      }
-      return;
-    }
-    callback(data);
-    return;
-  }
-
-  if (afterOption === true) {
-    const opt = strip(input.option).trim();
-    const match = cmd.options.find(o => o.short === opt || o.long === opt);
-    if (match) {
-      const config = match.autocomplete;
-      handleDataFormat(string, config, cb);
-      return;
-    }
-  }
-
-  let conf = cmd._autocomplete;
-  conf = conf && conf.data ? conf.data : conf;
-  handleDataFormat(string, conf, cb);
-  return;
-}
 
 export default autocomplete;

--- a/src/command.ts
+++ b/src/command.ts
@@ -5,7 +5,8 @@
 import { EventEmitter } from 'events';
 import _ from 'lodash';
 import Option from './option';
-import { ICommand, IVorpal } from './types';
+import {IAutocompleteConfig} from './types/autocomplete'
+import { ICommand, IVorpal } from './types/types';
 import util from './util';
 export interface Arg {
   required: boolean;
@@ -33,7 +34,6 @@ export default class Command extends EventEmitter implements ICommand {
   private _after;
   public _allowUnknownOptions;
   public _autocomplete;
-  public _autocompletion;
   public _done;
   public _cancel;
   private _usage;
@@ -191,34 +191,13 @@ export default class Command extends EventEmitter implements ICommand {
    * for the given command. Favored over
    * deprecated command.autocompletion.
    *
-   * @param {Function} fn
+   * @param {IAutocompleteConfig} conf
    * @return {Command}
    * @api public
    */
 
-  public autocomplete(obj) {
-    this._autocomplete = obj;
-    return this;
-  }
-
-  /**
-   * Defines tabbed auto-completion rules
-   * for the given command.
-   *
-   * @param {Function} fn
-   * @return {Command}
-   * @api public
-   */
-
-  public autocompletion(param) {
-    this._parent._useDeprecatedAutocompletion = true;
-    if (!_.isFunction(param) && !_.isObject(param)) {
-      throw new Error(
-        'An invalid object type was passed into the first parameter of command.autocompletion: function expected.'
-      );
-    }
-
-    this._autocompletion = param;
+  public autocomplete(conf: IAutocompleteConfig) {
+    this._autocomplete = conf;
     return this;
   }
 
@@ -465,7 +444,7 @@ export default class Command extends EventEmitter implements ICommand {
   /**
    * Returns the length of the longest option.
    *
-   * @return {Integer}
+   * @return {Number}
    * @api private
    */
 

--- a/src/types/autocomplete.ts
+++ b/src/types/autocomplete.ts
@@ -1,0 +1,27 @@
+import {ICommand} from './types'
+
+export interface IAutocomplete {
+    exec(str: string, cb: (error: Error | undefined, match: AutocompleteMatch) => unknown): void
+    match(str: string, arr: string[], options: AutocompleteOptions): AutocompleteMatch
+}
+
+export interface Input<T extends AutocompleteMatch = AutocompleteMatch> {
+    raw: string;
+    prefix: string;
+    suffix: string;
+    context: T;
+    match?: ICommand;
+    option?: string;
+}
+
+export interface AutocompleteOptions {
+    ignoreSlashes?: boolean
+}
+
+export type AutocompleteMatch = string | string[] | undefined
+
+export type AutocompleteCallback = (data: AutocompleteMatch) => unknown
+
+export type AutocompleteConfigCallback = (error: Error | undefined, arr: string[]) => void
+export type AutocompleteConfigFn = (input: AutocompleteMatch, callback: AutocompleteConfigCallback) => string[]
+export type IAutocompleteConfig =  string[] | {data: AutocompleteConfigFn}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
-import History from './history';
+import History from '../history';
+import Option from '../option'
+import {IAutocompleteConfig} from './autocomplete'
 
 export interface IVorpal extends EventEmitter {
   parent: IVorpal;
@@ -12,19 +14,20 @@ export interface IVorpal extends EventEmitter {
   session: any;
   prompt(options, cb);
   _commandHelp(command);
-  _useDeprecatedAutocompletion: boolean;
   _send(...argz); // TODO interface to change
 }
 
 export interface ICommand extends EventEmitter {
   commands: ICommand[];
-  options;
+  options: Option[];
   parent: IVorpal;
   _name: string;
   _catch: Function;
   _hidden: boolean;
   _help: Function;
   _aliases: string[];
+  _allowUnknownOptions: boolean
+  _autocomplete: IAutocompleteConfig
   option(flags, description, autocomplete?): ICommand;
   action(fn): ICommand;
   use(fn): ICommand;
@@ -32,8 +35,7 @@ export interface ICommand extends EventEmitter {
 
   cancel(fn): ICommand;
   done(fn);
-  autocomplete(obj);
-  autocompletion(param);
+  autocomplete(obj: IAutocompleteConfig);
   init(fn): ICommand;
   delimiter(delimiter);
   types(types);

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import _          from 'lodash';
 import minimist   from 'minimist';
 import strip      from 'strip-ansi';
 import { Arg }    from './command';
-import {ICommand} from './types'
+import {ICommand} from './types/types'
 
 interface Options {
   options: { [key: string]: any };
@@ -411,7 +411,7 @@ export default {
    * given width.
    *
    * @param {String} str
-   * @param {Integer} width
+   * @param {Number} width
    * @param {String} delimiter
    * @return {String}
    * @api private

--- a/src/vorpal-commons.ts
+++ b/src/vorpal-commons.ts
@@ -9,7 +9,7 @@
  */
 
 import _ from 'lodash';
-import { ICommand, IVorpal } from './types';
+import { IVorpal } from './types/types';
 
 export default function(vorpal: IVorpal) {
   /**

--- a/src/vorpal.ts
+++ b/src/vorpal.ts
@@ -14,7 +14,7 @@ import History from './history';
 import intercept from './intercept';
 import LocalStorage from './local-storage';
 import Session from './session';
-import { IVorpal } from './types';
+import { IVorpal } from './types/types';
 import ui from './ui';
 import VorpalUtil from './util';
 import commons from './vorpal-commons';
@@ -49,7 +49,6 @@ export default class Vorpal extends EventEmitter implements IVorpal {
   private _delimiter: string;
   private server: { sessions: any[] };
   private _hooked: boolean;
-  public _useDeprecatedAutocompletion: boolean;
   public util: any;
   public Session: typeof Session;
   public session: any;
@@ -107,8 +106,6 @@ export default class Vorpal extends EventEmitter implements IVorpal {
 
     // Whether all stdout is being hooked through a function.
     this._hooked = false;
-
-    this._useDeprecatedAutocompletion = false;
 
     // Expose common utilities, like padding.
     this.util = VorpalUtil;
@@ -1331,12 +1328,12 @@ export default class Vorpal extends EventEmitter implements IVorpal {
   /**
    * Returns session by id.
    *
-   * @param {Integer} id
+   * @param {String} id
    * @return {Session}
    * @api public
    */
 
-  public getSessionById(id) {
+  public getSessionById(id: string) {
     if (_.isObject(id)) {
       throw new Error(
         'vorpal.getSessionById: id ' + JSON.stringify(id) + ' should not be an object.'


### PR DESCRIPTION
Removed deprecated "autocompletion" API.
"autocomplete" API is now used in calculator example. Good developer experience.

sidenote: specifically the "double" use case is not supported any more in "autocomplete" API (it was a hack anyway) so the example actually breaks, but it shows the intellisense.

I added some types and refactored the whole module.
For both autocomplete.ts and autocomplete-utils.ts there are 0 noImplicitAny errors.